### PR TITLE
fix: move generic/aggressive vars to opt-in section, fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,23 @@
 # do-not-track-cli
 
-A comprehensive `.env` file that opts out of telemetry, analytics, and data
-collection across 100+ CLI tools, frameworks, SDKs, and runtimes — in one
-place.
+A single `.env` file to opt out of telemetry across CLI tools, frameworks, SDKs, and runtimes.
 
 ## Why
 
-[donottrack.sh](https://donottrack.sh/) promotes a single universal variable
-(`DO_NOT_TRACK=1`), but most tools haven't adopted it. Every framework invents
-its own opt-out variable, buried in its docs.
+[donottrack.sh](https://donottrack.sh/) promotes a universal `DO_NOT_TRACK=1` variable, but most tools haven't adopted it. Each framework defines its own opt-out variable, usually buried in its docs.
 
-[toptout](https://github.com/beatcracker/toptout) has the most complete data
-set but outputs complex conditional shell scripts that require PowerShell or
-careful sourcing.
+[toptout](https://github.com/beatcracker/toptout) maintains the most complete dataset but generates complex shell scripts that require PowerShell or careful conditional sourcing.
 
-This project takes a different approach: a single, flat `.env` file you can
-drop anywhere, source once, and forget.
-
-> "Collecting all the 'do not track' env vars into a single 'do_not_track.env'
-> file... may not be a bad idea" — [PufPufPuf](https://news.ycombinator.com/item?id=47989846),
-> in response to a [Hacker News discussion](https://news.ycombinator.com/item?id=47988592)
-> about [donottrack.sh](https://donottrack.sh/)
-
-The `DO_NOT_TRACK` standard itself was created by
-[sneak (Jeffrey Paul)](https://github.com/sneak/consoledonottrack.com) at
-[consoledonottrack.com](https://consoledonottrack.com/).
+This project maintains a single, flat `.env` file. Source it in your shell profile, load it in `docker-compose.yml`, or use it with direnv — no scripting required.
 
 ## Quick Start
 
 ```sh
-# Clone or download
 git clone https://github.com/alloydwhitlock/do-not-track-cli.git
-
-# Source it in your current shell session
 set -a && source do_not_track.env && set +a
 ```
 
-Add to your shell profile to apply permanently:
+To persist across sessions, add to your shell profile:
 
 ```sh
 # ~/.zshrc or ~/.bashrc
@@ -75,13 +56,12 @@ services:
 - name: Disable telemetry
   run: |
     set -a && source do_not_track.env && set +a
-    echo "Sourced $( grep -c '=' do_not_track.env ) opt-out variables"
+    echo "Sourced $( grep -cE '^[A-Z_]+=' do_not_track.env ) opt-out variables"
 ```
 
 ### 12-factor apps / dotenv
 
-Any tool that loads `.env` files (dotenv, direnv, docker, compose) can consume
-`do_not_track.env` directly.
+Any tool that loads `.env` files (dotenv, direnv, Docker, Compose) can consume `do_not_track.env` directly.
 
 ## What's covered
 
@@ -99,6 +79,16 @@ Any tool that loads `.env` files (dotenv, direnv, docker, compose) can consume
 
 Full list: see [`do_not_track.env`](./do_not_track.env).
 
+### Aggressive opt-ins
+
+Some variables do more than disable telemetry — they block network access or use generic names that may conflict with other tools. These are in a commented-out section at the bottom of `do_not_track.env`. Uncomment the ones you want after verifying they won't break other tools in your environment.
+
+| Variable | Tool | Side effect |
+|---|---|---|
+| `HF_HUB_OFFLINE=1` | Hugging Face Hub | Blocks all connections to hf.co, including model and dataset downloads |
+| `ANALYTICS=no` | AccessMap | Generic name; may affect other tools that check `$ANALYTICS` |
+| `TELEMETRY_ENABLED=0` | projector-cli | Generic name; may affect other tools that check `$TELEMETRY_ENABLED` |
+
 ## Contributing
 
 Pull requests welcome. To add a tool:
@@ -110,26 +100,18 @@ Pull requests welcome. To add a tool:
    TOOL_TELEMETRY_DISABLED=1
    ```
 3. Include the tool name as a comment and the correct opt-out value.
-4. Open a PR with the tool name and a link to the official docs in the
-   description.
+4. Open a PR with the tool name and a link to the official docs in the description.
 
 **Notes:**
-- Use the actual opt-out value from official docs (not just `1` if the tool
-  expects `true` or `false`).
-- If a tool already respects `DO_NOT_TRACK=1` (set at the top of the file),
-  note it with a comment rather than adding a redundant entry.
-- Generic variables like `CI=1` are intentionally excluded — they alter
-  unrelated tool behavior.
+- Use the actual opt-out value from official docs (not just `1` if the tool expects `true` or `false`).
+- If a tool already respects `DO_NOT_TRACK=1` (set at the top of the file), note it with a comment rather than adding a redundant entry.
+- Generic variables like `CI=1` are excluded — they alter unrelated tool behavior. Variables that affect more than telemetry belong in the aggressive opt-ins section at the bottom of the file.
 
 ## Credits
 
-- [sneak (Jeffrey Paul)](https://github.com/sneak) — created the
-  [DO_NOT_TRACK / Console Do Not Track](https://consoledonottrack.com/) standard
-- [beatcracker/toptout](https://github.com/beatcracker/toptout) — the most
-  comprehensive data source for tool-specific opt-out variables; many entries
-  here are sourced from that project
-- [PufPufPuf](https://news.ycombinator.com/item?id=47989846) — suggested the
-  `.env` file format approach on Hacker News
+- [sneak (Jeffrey Paul)](https://github.com/sneak) — created the [DO_NOT_TRACK / Console Do Not Track](https://consoledonottrack.com/) standard
+- [beatcracker/toptout](https://github.com/beatcracker/toptout) — the most comprehensive data source for tool-specific opt-out variables; many entries here are sourced from that project
+- [PufPufPuf](https://news.ycombinator.com/item?id=47989846) — suggested the `.env` file format approach on Hacker News
 
 ## License
 

--- a/do_not_track.env
+++ b/do_not_track.env
@@ -279,10 +279,7 @@ F5_ALLOW_TELEMETRY=false
 GEMINI_TELEMETRY_ENABLED=false
 
 # Hugging Face Hub (python transformers / diffusers / datasets)
-# HF_HUB_DISABLE_TELEMETRY stops usage reporting
-# HF_HUB_OFFLINE=1 also prevents any outbound connections to hf.co
 HF_HUB_DISABLE_TELEMETRY=1
-HF_HUB_OFFLINE=1
 
 # Hookdeck CLI
 HOOKDECK_CLI_TELEMETRY_OPTOUT=1
@@ -311,9 +308,6 @@ MSLAB_TELEMETRY_LEVEL=None
 
 # PnP PowerShell
 PNPPOWERSHELL_DISABLETELEMETRY=true
-
-# projector-cli
-TELEMETRY_ENABLED=0
 
 # Telepresence (CNCF)
 SCOUT_DISABLE=1
@@ -347,11 +341,32 @@ CARBON_TELEMETRY_DISABLED=1
 # Automagica
 AUTOMAGICA_NO_TELEMETRY=1
 
-# AccessMap
-ANALYTICS=no
-
 # JavaScript debugger (VSCode)
 DA_TEST_DISABLE_TELEMETRY=1
 
 # Azure Application Insights VSCode extension
 AITOOLSVSCODE_DISABLETELEMETRY=1
+
+# ──────────────────────────────────────────────
+# Aggressive / Opt-in
+# ──────────────────────────────────────────────
+# These variables go beyond disabling telemetry. They block network access,
+# suppress system notifications, or use generic names likely to collide with
+# other tools in your environment. They are commented out by default.
+#
+# Uncomment only the ones you want, and verify they don't break other tools.
+
+# Hugging Face Hub — blocks ALL outbound connections to hf.co.
+# This prevents model and dataset downloads, not just usage reporting.
+# Only set this in fully offline or air-gapped environments.
+# HF_HUB_OFFLINE=1
+
+# AccessMap — disables analytics for the AccessMap routing tool, but the
+# variable name ANALYTICS is generic enough to interfere with other tools
+# that check $ANALYTICS in their own startup logic.
+# ANALYTICS=no
+
+# projector-cli — disables telemetry for JetBrains projector-cli, but
+# TELEMETRY_ENABLED is a common pattern used by many tools. Setting this
+# globally may silently affect other tools in your environment.
+# TELEMETRY_ENABLED=0


### PR DESCRIPTION
## What

Three environment variables in `do_not_track.env` were problematic:

- `HF_HUB_OFFLINE=1` — blocks **all** outbound connections to hf.co, not just telemetry. Will silently break model and dataset downloads for anyone sourcing this file.
- `ANALYTICS=no` — generic variable name; the README's own contributing policy excludes these because they "alter unrelated tool behavior."
- `TELEMETRY_ENABLED=0` — same issue; common enough that other tools likely check it.

The CI/CD example in the README also had a bug: `grep -c '='` counts comment lines that contain `=` (e.g. the commented-out `BUN_DISABLE_TELEMETRY=1` line), inflating the reported count.

## Changes

**`do_not_track.env`**
- Remove the three variables from the main body of the file
- Add an `Aggressive / Opt-in` section at the bottom with all three commented out and documented, explaining what each one actually does and why it's opt-in

**`README.md`**
- Fix `grep -c '='` → `grep -cE '^[A-Z_]+='` in the GitHub Actions example
- Add an "Aggressive opt-ins" subsection under "What's covered" with a table describing each variable and its side effect
- Update the Contributing notes to direct risky variables to the aggressive opt-ins section
- General cleanup: remove HN blockquote, tighten phrasing

## Testing

```sh
# Verify active variable count is accurate
grep -cE '^[A-Z_]+=' do_not_track.env

# Verify the three problematic vars are commented out in main body
grep -E '^(ANALYTICS|TELEMETRY_ENABLED|HF_HUB_OFFLINE)=' do_not_track.env
# should return nothing

# Verify they exist in the aggressive section (commented)
grep -E '#.*HF_HUB_OFFLINE|#.*ANALYTICS=no|#.*TELEMETRY_ENABLED' do_not_track.env
```