### PR TITLE
feat: add LICENSE, PR template, CI validation, and issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/add-tool.yml
+++ b/.github/ISSUE_TEMPLATE/add-tool.yml
@@ -1,0 +1,48 @@
+name: Add a tool
+description: Request a new telemetry opt-out variable be added to do_not_track.env
+labels: ["enhancement"]
+body:
+  - type: input
+    id: tool_name
+    attributes:
+      label: Tool name
+      description: Name of the CLI tool, framework, or SDK
+    validations:
+      required: true
+
+  - type: input
+    id: variable
+    attributes:
+      label: Opt-out variable and value
+      placeholder: "TOOL_TELEMETRY_DISABLED=1"
+    validations:
+      required: true
+
+  - type: input
+    id: docs_link
+    attributes:
+      label: Official documentation link
+      description: Direct link to the page confirming this variable and its value
+    validations:
+      required: true
+
+  - type: dropdown
+    id: generic_var
+    attributes:
+      label: Is the variable name specific to this tool?
+      description: Generic names like ANALYTICS or TELEMETRY_ENABLED may conflict with other tools and belong in the Aggressive / Opt-in section.
+      options:
+        - "Yes — the name is tool-specific"
+        - "No — the name is generic"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I verified the opt-out value from official documentation (not just assumed `1`)
+          required: true
+        - label: I checked that this tool doesn't already respect `DO_NOT_TRACK=1`
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Tool
+
+<!-- Name of the CLI tool, framework, or SDK -->
+
+## Opt-out variable
+
+```
+VARIABLE_NAME=value
+```
+
+## Official documentation
+
+<!-- Direct link to the docs page confirming this variable and value -->
+
+## Notes
+
+<!-- Check any that apply -->
+- [ ] This tool does not already respect `DO_NOT_TRACK=1` (if it does, add a comment instead)
+- [ ] The variable name is specific to this tool (generic names like `ANALYTICS` or `TELEMETRY_ENABLED` belong in the Aggressive / Opt-in section)
+- [ ] The opt-out value matches official docs exactly (e.g. `true` not `1` if that's what the tool expects)

--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -1,0 +1,40 @@
+name: Validate do_not_track.env
+
+on:
+  push:
+    paths:
+      - 'do_not_track.env'
+  pull_request:
+    paths:
+      - 'do_not_track.env'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Check for duplicate variable names
+        run: |
+          dupes=$(grep -E '^[A-Z_]+=' do_not_track.env | cut -d= -f1 | sort | uniq -d)
+          if [ -n "$dupes" ]; then
+            echo "Duplicate variable names:"
+            echo "$dupes"
+            exit 1
+          fi
+          echo "No duplicates found."
+
+      - name: Validate line format
+        run: |
+          bad=$(grep -vE '^\s*$|^#|^[A-Z_]+=' do_not_track.env)
+          if [ -n "$bad" ]; then
+            echo "Malformed lines (not a comment, blank, or valid assignment):"
+            echo "$bad"
+            exit 1
+          fi
+          echo "Format valid."
+
+      - name: Report active variable count
+        run: |
+          count=$(grep -cE '^[A-Z_]+=' do_not_track.env)
+          echo "Active opt-out variables: $count"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 alloydwhitlock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## What

Four missing project infrastructure pieces:

**LICENSE** — the README declared MIT but no LICENSE file existed; GitHub couldn't detect the license.

**PR template** (`.github/pull_request_template.md`) — enforces the contributing checklist at submission time: tool name, official docs link, correct opt-out value, and a note about generic variable names.

**CI validation** (`.github/workflows/validate-env.yml`) — runs on any PR or push touching `do_not_track.env`. Checks for duplicate variable names, malformed lines, and reports the active variable count.

**Issue template** (`.github/ISSUE_TEMPLATE/add-tool.yml`) — structured form for "add a tool" requests that requires a docs link and flags generic variable names up front.