### PR TITLE
feat: add tag-triggered auto-release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Count active opt-out variables
+        id: count
+        run: |
+          count=$(grep -cE '^[A-Z_]+=' do_not_track.env)
+          echo "count=$count" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.ref_name }}
+          REPO: ${{ github.repository }}
+          VAR_COUNT: ${{ steps.count.outputs.count }}
+        run: |
+          prev_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || echo "")
+          if [ -n "$prev_tag" ]; then
+            changelog_url="https://github.com/${REPO}/compare/${prev_tag}...${TAG_NAME}"
+          else
+            changelog_url="https://github.com/${REPO}/commits/${TAG_NAME}"
+          fi
+          gh release create "$TAG_NAME" \
+            --title "$TAG_NAME" \
+            --notes "## do_not_track.env
+
+Active opt-out variables: ${VAR_COUNT}
+
+See [CHANGELOG](${changelog_url}) for what changed, or browse [\`do_not_track.env\`](https://github.com/${REPO}/blob/${TAG_NAME}/do_not_track.env) for the full list."


### PR DESCRIPTION
Automates GitHub releases when a `v*` tag is pushed.

The release notes include the count of active opt-out variables at that tag. To cut a release:

```sh
git tag v1.1.0
git push origin v1.1.0
```