### PR TITLE
feat: add missing tools from toptout gap analysis

### DIFF
--- a/do_not_track.env
+++ b/do_not_track.env
@@ -155,6 +155,9 @@ SFDX_DISABLE_TELEMETRY=true
 # GitHub CLI (gh) — added in v2.91.0, April 2026
 GH_TELEMETRY=false
 
+# Supabase CLI (also respects DO_NOT_TRACK=1 above)
+SUPABASE_TELEMETRY_DISABLED=1
+
 # Cloudflare Wrangler
 WRANGLER_SEND_METRICS=false
 
@@ -199,6 +202,12 @@ FEAST_TELEMETRY=false
 MM_LOGSETTINGS_ENABLEDIAGNOSTICS=false
 MM_SERVICESETTINGS_ENABLESECURITYFIXALERT=false
 
+# Canvas LMS
+CANVAS_LMS_STATS_COLLECTION=opt_out
+
+# otel-launcher-node (Lightstep host metrics)
+LS_METRICS_HOST_ENABLED=0
+
 # One Codex
 ONE_CODEX_NO_TELEMETRY=true
 
@@ -207,6 +216,9 @@ SQA_OPT_OUT=true
 
 # Oryx (Microsoft build tool)
 ORYX_DISABLE_TELEMETRY=true
+
+# PROSE Code Accelerator SDK (Microsoft Research)
+PROSE_TELEMETRY_OPTOUT=1
 
 # RASA (conversational AI)
 RASA_TELEMETRY_ENABLED=false
@@ -334,6 +346,12 @@ AUTOMATEDLAB_TELEMETRY_OPTOUT=1
 
 # aliBuild (ALICE/CERN)
 ALIBUILD_NO_ANALYTICS=1
+
+# kubeapt (Kubernetes dashboard)
+DASH_DISABLE_TELEMETRY=1
+
+# Testim Root Cause (failure analysis)
+SUGGESTIONS_OPT_OUT=1
 
 # Carbon Design System
 CARBON_TELEMETRY_DISABLED=1


### PR DESCRIPTION
## Summary

Cross-referenced the [toptout dataset](https://github.com/beatcracker/toptout) against all active and commented entries in `do_not_track.env` to find gaps. Added six confirmed env-var opt-outs:

- **Supabase CLI** — `SUPABASE_TELEMETRY_DISABLED=1` (confirmed from [source](https://github.com/supabase/cli/blob/main/internal/telemetry/state.go); also respects `DO_NOT_TRACK=1`)
- **Canvas LMS** — `CANVAS_LMS_STATS_COLLECTION=opt_out` (toptout: [canvas-lms.json](https://github.com/beatcracker/toptout/blob/master/data/canvas-lms.json))
- **otel-launcher-node** — `LS_METRICS_HOST_ENABLED=0` (toptout: [otel-launcher-node.json](https://github.com/beatcracker/toptout/blob/master/data/otel-launcher-node.json))
- **PROSE Code Accelerator SDK** — `PROSE_TELEMETRY_OPTOUT=1` (toptout: [prose-sdk.json](https://github.com/beatcracker/toptout/blob/master/data/prose-sdk.json))
- **kubeapt** — `DASH_DISABLE_TELEMETRY=1` (toptout: [kubeapt.json](https://github.com/beatcracker/toptout/blob/master/data/kubeapt.json))
- **Testim Root Cause** — `SUGGESTIONS_OPT_OUT=1` (toptout: [root-cause.json](https://github.com/beatcracker/toptout/blob/master/data/root-cause.json))

**Tools checked but not added** (no env var available — cmd-only or config-file-only opt-out): Flutter, Ionic CLI, Capacitor, Netlify CLI, Skaffold, DVC, Ember CLI, Stencil, Nx, Scaleway CLI, Power Platform CLI, react-admin, k0s, Lens, BuildBuddy, LocalStack (`DISABLE_EVENTS` is too generic), Sentry CLI (no telemetry env var found), Supabase (covered by `DO_NOT_TRACK=1` already but added explicit var for clarity).

Source: https://github.com/beatcracker/toptout

## Test plan

- [x] Verify each variable name and opt-out value matches the toptout source JSON or official docs
- [x] Confirm no variable is duplicated (active or commented) in the existing file
- [x] Source the file and confirm no shell errors: `set -a && source do_not_track.env && set +a`