### PR TITLE
fix: allow digits in variable name regex

### DIFF
--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Check for duplicate variable names
         run: |
-          dupes=$(grep -E '^[A-Z_]+=' do_not_track.env | cut -d= -f1 | sort | uniq -d)
+          dupes=$(grep -E '^[A-Z_][A-Z0-9_]*=' do_not_track.env | cut -d= -f1 | sort | uniq -d)
           if [ -n "$dupes" ]; then
             echo "Duplicate variable names:"
             echo "$dupes"
@@ -26,7 +26,7 @@ jobs:
 
       - name: Validate line format
         run: |
-          bad=$(grep -vE '^\s*$|^#|^[A-Z_]+=' do_not_track.env)
+          bad=$(grep -vE '^\s*$|^#|^[A-Z_][A-Z0-9_]*=' do_not_track.env)
           if [ -n "$bad" ]; then
             echo "Malformed lines (not a comment, blank, or valid assignment):"
             echo "$bad"
@@ -36,5 +36,5 @@ jobs:
 
       - name: Report active variable count
         run: |
-          count=$(grep -cE '^[A-Z_]+=' do_not_track.env)
+          count=$(grep -cE '^[A-Z_][A-Z0-9_]*=' do_not_track.env)
           echo "Active opt-out variables: $count"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ services:
 - name: Disable telemetry
   run: |
     set -a && source do_not_track.env && set +a
-    echo "Sourced $( grep -cE '^[A-Z_]+=' do_not_track.env ) opt-out variables"
+    echo "Sourced $( grep -cE '^[A-Z_][A-Z0-9_]*=' do_not_track.env ) opt-out variables"
 ```
 
 ### 12-factor apps / dotenv


### PR DESCRIPTION
The regex `^[A-Z_]+=` rejects variable names containing digits, which caused `F5_ALLOW_TELEMETRY=false` to be flagged as a malformed line.

Fixed to `^[A-Z_][A-Z0-9_]*=` in all four places the pattern appears:
- `validate-env.yml` duplicate check
- `validate-env.yml` format validation (the failing step)
- `validate-env.yml` active variable count
- `README.md` CI/CD example

Fixes the CI failure on the current `do_not_track.env`.