### PR TITLE
fix: avoid blank lines in YAML block scalar, fix digit regex

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Count active opt-out variables
         id: count
         run: |
-          count=$(grep -cE '^[A-Z_]+=' do_not_track.env)
+          count=$(grep -cE '^[A-Z_][A-Z0-9_]*=' do_not_track.env)
           echo "count=$count" >> "$GITHUB_OUTPUT"
 
       - name: Create release
@@ -32,10 +32,8 @@ jobs:
           else
             changelog_url="https://github.com/${REPO}/commits/${TAG_NAME}"
           fi
+          printf '## do_not_track.env\n\nActive opt-out variables: %s\n\nSee [CHANGELOG](%s) for what changed, or browse [do_not_track.env](https://github.com/%s/blob/%s/do_not_track.env) for the full list.\n' \
+            "${VAR_COUNT}" "${changelog_url}" "${REPO}" "${TAG_NAME}" > /tmp/release_notes.md
           gh release create "$TAG_NAME" \
             --title "$TAG_NAME" \
-            --notes "## do_not_track.env
-
-Active opt-out variables: ${VAR_COUNT}
-
-See [CHANGELOG](${changelog_url}) for what changed, or browse [\`do_not_track.env\`](https://github.com/${REPO}/blob/${TAG_NAME}/do_not_track.env) for the full list."
+            --notes-file /tmp/release_notes.md


### PR DESCRIPTION
## Problem

Line 41 YAML syntax error: the `--notes` argument embedded a multi-line string with blank lines (zero bytes, no indentation) inside a deeply-indented `run: |` block scalar. GitHub Actions' YAML parser sees those zero-byte blank lines as having indentation level 0, which is less than the block's indentation level, and rejects the file.

## Fix

Write the release notes to `/tmp/release_notes.md` using `printf` and pass `--notes-file` instead. No blank lines appear in the YAML at all.

Also picks up the digit-in-variable-name regex fix from PR #8 (`^[A-Z_]+=` → `^[A-Z_][A-Z0-9_]*=`) so this workflow counts `F5_ALLOW_TELEMETRY` correctly.