### PR TITLE
fix: handle grep -v exit code 1 on valid input

### DIFF
--- a/.github/workflows/validate-env.yml
+++ b/.github/workflows/validate-env.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Validate line format
         run: |
-          bad=$(grep -vE '^\s*$|^#|^[A-Z_][A-Z0-9_]*=' do_not_track.env)
+          bad=$(grep -vE '^\s*$|^#|^[A-Z_][A-Z0-9_]*=' do_not_track.env) || true
           if [ -n "$bad" ]; then
             echo "Malformed lines (not a comment, blank, or valid assignment):"
             echo "$bad"


### PR DESCRIPTION
## Root cause

`grep -v` returns exit code 1 when no lines match — which means the file is valid. GitHub Actions runs `run:` steps with `bash -e`, so that non-zero exit code kills the step before `if [ -n "$bad" ]` is ever evaluated. A clean, valid `do_not_track.env` fails CI; a file with actual malformed lines would pass (grep returns 0).

## Fix

```diff
- bad=$(grep -vE '^\s*$|^#|^[A-Z_][A-Z0-9_]*=' do_not_track.env)
+ bad=$(grep -vE '^\s*$|^#|^[A-Z_][A-Z0-9_]*=' do_not_track.env) || true
```

`|| true` lets the assignment complete regardless of grep's exit code. `$bad` is still empty when there are no matches, so the `if [ -n "$bad" ]` check works correctly in both cases.

Merge this first, then rebase PR #6 to unblock it.