### PR TITLE
feat: auto-tag patch release when do_not_track.env changes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -1,0 +1,32 @@
+name: Auto-tag on env change
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'do_not_track.env'
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump patch version and push tag
+        run: |
+          latest=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          version="${latest#v}"
+          major=$(echo "$version" | cut -d. -f1)
+          minor=$(echo "$version" | cut -d. -f2)
+          patch=$(echo "$version" | cut -d. -f3)
+          new_tag="v${major}.${minor}.$((patch + 1))"
+          echo "Tagging $latest -> $new_tag"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$new_tag"
+          git push origin "$new_tag"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ A few things to check first:
 - If the tool already respects `DO_NOT_TRACK=1`, add a comment noting that rather than a new entry.
 - If the variable name is generic (like `ANALYTICS` or `TELEMETRY_ENABLED`), it belongs in the aggressive opt-ins section at the bottom of the file.
 
+## Versioning
+
+This project uses [semantic versioning](https://semver.org/). Patch releases (`v1.0.x`) are cut automatically whenever `do_not_track.env` is updated on main. Minor and major bumps are done manually for significant changes such as structural reorganization or policy updates.
+
+All releases are at [github.com/alloydwhitlock/do-not-track-cli/releases](https://github.com/alloydwhitlock/do-not-track-cli/releases). To pin to a specific version in CI, reference a release tag directly:
+
+```sh
+git clone --depth 1 --branch v1.0.0 https://github.com/alloydwhitlock/do-not-track-cli.git
+set -a && source do_not_track.env && set +a
+```
+
 ## Credits
 
 [sneak (Jeffrey Paul)](https://github.com/sneak) created the [DO_NOT_TRACK / Console Do Not Track](https://consoledonottrack.com/) standard that many tools now support.


### PR DESCRIPTION
## What

Adds `auto-tag.yml` — a workflow that fires whenever `do_not_track.env` is merged to main. It reads the latest semver tag, bumps the patch version, and pushes the new tag, which in turn triggers the existing `release.yml` to publish a GitHub release automatically.

**Flow:**
```
PR merged to main (do_not_track.env changed)
  → auto-tag.yml runs
  → reads latest tag (e.g. v1.0.0)
  → pushes v1.0.1
  → release.yml fires on new tag
  → GitHub release published with variable count and changelog link
```

Minor and major version bumps remain manual (`git tag v2.0.0 && git push origin v2.0.0`).

Also adds a **Versioning** section to the README explaining how this works and how to pin to a specific release tag in CI.