### PR TITLE
feat: add Vercel CLI, AWS CDK, Redocly, Encore, Railway

### DIFF
--- a/do_not_track.env
+++ b/do_not_track.env
@@ -135,6 +135,9 @@ PANTS_ANONYMOUS_TELEMETRY_ENABLED=false
 # werf
 WERF_TELEMETRY=0
 
+# AWS CDK
+CDK_DISABLE_CLI_TELEMETRY=true
+
 # ──────────────────────────────────────────────
 # Cloud Provider CLIs
 # ──────────────────────────────────────────────
@@ -157,6 +160,12 @@ GH_TELEMETRY=false
 
 # Supabase CLI (also respects DO_NOT_TRACK=1 above)
 SUPABASE_TELEMETRY_DISABLED=1
+
+# Vercel CLI
+VERCEL_TELEMETRY_DISABLED=1
+
+# Railway (also respects DO_NOT_TRACK=1 above)
+RAILWAY_NO_TELEMETRY=1
 
 # Cloudflare Wrangler
 WRANGLER_SEND_METRICS=false
@@ -241,6 +250,12 @@ APOLLO_TELEMETRY_DISABLED=1
 
 # Salto CLI
 SALTO_TELEMETRY_DISABLE=1
+
+# Redocly CLI
+REDOCLY_TELEMETRY=off
+
+# Encore
+DISABLE_ENCORE_TELEMETRY=1
 
 # Stripe CLI
 STRIPE_CLI_TELEMETRY_OPTOUT=1


### PR DESCRIPTION
Adds 5 tools confirmed from official documentation. All pass the format validator locally (111 active variables total).

| Tool | Variable | Value | Docs |
|---|---|---|---|
| AWS CDK | `CDK_DISABLE_CLI_TELEMETRY` | `true` | [AWS CDK v2 Telemetry](https://docs.aws.amazon.com/cdk/v2/guide/cli-telemetry.html) |
| Vercel CLI | `VERCEL_TELEMETRY_DISABLED` | `1` | [Vercel CLI Telemetry](https://vercel.com/docs/cli/about-telemetry) |
| Railway | `RAILWAY_NO_TELEMETRY` | `1` | [Railway Telemetry](https://docs.railway.com/cli/telemetry) — also respects `DO_NOT_TRACK=1` |
| Redocly CLI | `REDOCLY_TELEMETRY` | `off` | [Redocly Usage Data](https://redocly.com/docs/cli/usage-data) |
| Encore | `DISABLE_ENCORE_TELEMETRY` | `1` | [Encore Telemetry](https://encore.dev/docs/ts/cli/telemetry) |

Tools checked but not added (no env var, CLI-flag only): AWS Amplify, Firebase Tools, Fly.io, Biome, Netlify CLI, Ansible, OpenShift CLI, Rancher Desktop, Nx, Buf CLI, PlanetScale, Turso.