### PR TITLE
feat: auto-tag workflow handles release creation directly

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,7 +8,7 @@ on:
       - 'do_not_track.env'
 
 jobs:
-  tag:
+  tag-and-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -18,6 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Bump patch version and push tag
+        id: tag
         run: |
           latest=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           version="${latest#v}"
@@ -30,3 +31,24 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag "$new_tag"
           git push origin "$new_tag"
+          echo "new_tag=$new_tag" >> "$GITHUB_OUTPUT"
+          echo "prev_tag=$latest" >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_TAG: ${{ steps.tag.outputs.new_tag }}
+          PREV_TAG: ${{ steps.tag.outputs.prev_tag }}
+          REPO: ${{ github.repository }}
+        run: |
+          count=$(grep -cE '^[A-Z_][A-Z0-9_]*=' do_not_track.env)
+          if [ "$PREV_TAG" != "v0.0.0" ]; then
+            changelog_url="https://github.com/${REPO}/compare/${PREV_TAG}...${NEW_TAG}"
+          else
+            changelog_url="https://github.com/${REPO}/commits/${NEW_TAG}"
+          fi
+          printf '## do_not_track.env\n\nActive opt-out variables: %s\n\nSee [CHANGELOG](%s) for what changed, or browse [do_not_track.env](https://github.com/%s/blob/%s/do_not_track.env) for the full list.\n' \
+            "$count" "$changelog_url" "$REPO" "$NEW_TAG" > /tmp/release_notes.md
+          gh release create "$NEW_TAG" \
+            --title "$NEW_TAG" \
+            --notes-file /tmp/release_notes.md

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   release:
+    # auto-tag.yml handles releases for automated patch bumps.
+    # This job only runs for manually pushed tags (major/minor bumps).
+    if: github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## What

Previously there were two hops: `auto-tag.yml` pushed a tag, which triggered `release.yml` to create the release. This PR collapses that into one workflow.

**`auto-tag.yml`** now:
1. Bumps the patch version and pushes the tag (same as before)
2. Immediately creates the GitHub release using the new tag — no second workflow needed

**`release.yml`** gains an `if: github.actor != 'github-actions[bot]'` guard so it only fires for manually pushed tags (major/minor bumps like `git tag v2.0.0 && git push origin v2.0.0`). Without this guard, both workflows would run for every auto-patch tag and produce a duplicate release error.

## Flow after this PR

```
do_not_track.env merged to main
  → auto-tag.yml: bumps tag + creates release (one job)

git tag v2.0.0 && git push origin v2.0.0 (manual)
  → release.yml: creates release (actor is human, guard passes)
```