### PR TITLE
chore: clear weekly staleness backlog (W19-W30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A few variables go further than disabling telemetry. They're in a commented-out 
 | `HF_HUB_OFFLINE=1` | Hugging Face Hub | Blocks all connections to hf.co, model downloads included |
 | `ANALYTICS=no` | AccessMap | Generic name that may affect other tools checking `$ANALYTICS` |
 | `TELEMETRY_ENABLED=0` | projector-cli | Common enough to collide with other tools |
+| `DISABLE_TELEMETRY=1` / `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` | Claude Code | Community reports say this also disables client-side feature-flag evaluation, gating off unrelated product features — not just telemetry |
 
 ## Contributing
 

--- a/do_not_track.env
+++ b/do_not_track.env
@@ -17,6 +17,11 @@
 # Many modern tools check DO_NOT_TRACK=1 before sending telemetry.
 # Setting this is a good baseline even for tools not listed below.
 # See: https://donottrack.sh
+#
+# Known interaction: in Claude Code, DO_NOT_TRACK=1 triggers the same
+# non-default privacy code path as DISABLE_TELEMETRY, which community
+# reports say also disables client-side feature-flag evaluation (GrowthBook)
+# — see the Claude Code entry in the "Aggressive / Opt-in" section below.
 DO_NOT_TRACK=1
 
 # ──────────────────────────────────────────────
@@ -24,8 +29,9 @@ DO_NOT_TRACK=1
 # ──────────────────────────────────────────────
 
 # Angular CLI
+# NG_CLI_ANALYTICS_SHARE was removed without replacement in Angular CLI v15
+# (the analyticsSharing feature was dropped); NG_CLI_ANALYTICS is still valid.
 NG_CLI_ANALYTICS=false
-NG_CLI_ANALYTICS_SHARE=false
 
 # Astro
 ASTRO_TELEMETRY_DISABLED=1
@@ -43,6 +49,10 @@ NUXT_TELEMETRY_DISABLED=1
 STRAPI_TELEMETRY_DISABLED=true
 STRAPI_DISABLE_UPDATE_NOTIFICATION=true
 
+# Storybook (env var is required; the main.js config option alone doesn't
+# suppress the boot-time telemetry event)
+STORYBOOK_DISABLE_TELEMETRY=1
+
 # Turborepo
 TURBO_TELEMETRY_DISABLED=1
 
@@ -52,8 +62,14 @@ VUEDX_TELEMETRY=off
 # webhint
 HINT_TELEMETRY=off
 
-# Webiny
-REACT_APP_WEBINY_TELEMETRY=false
+# Webiny — no working env var. REACT_APP_WEBINY_TELEMETRY was a leftover
+# Create React App convention from before Webiny dropped CRA; current docs
+# only document `yarn webiny disable-telemetry` (CLI-only opt-out).
+# See: https://www.webiny.com/docs/webiny-telemetry/webiny-telemetry
+
+# MUI X (@mui/x-* packages: Data Grid, Date Pickers, Charts)
+# Must be set in the Node.js process environment (not NEXT_PUBLIC_/REACT_APP_-prefixed).
+MUI_X_TELEMETRY_DISABLED=true
 
 # SKU (Seek's build toolchain)
 SKU_TELEMETRY=false
@@ -84,6 +100,23 @@ DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=1
 
 # dotnet-svcutil
 DOTNET_SVCUTIL_TELEMETRY_OPTOUT=1
+
+# .NET Upgrade Assistant (tool is officially deprecated in favor of the
+# GitHub Copilot modernization agent, but still ships this opt-out)
+DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT=1
+
+# dotnet-scaffold (ASP.NET Core scaffolding CLI, .NET 9+)
+DOTNET_SCAFFOLD_TELEMETRY_OPTOUT=1
+
+# .NET HttpRepl
+DOTNET_HTTPREPL_TELEMETRY_OPTOUT=1
+
+# Microsoft.Testing.Platform (xUnit v3, NUnit, MSTest on the new test runner;
+# DOTNET_CLI_TELEMETRY_OPTOUT above also satisfies this)
+TESTINGPLATFORM_TELEMETRY_OPTOUT=1
+
+# .NET Aspire CLI
+ASPIRE_CLI_TELEMETRY_OPTOUT=true
 
 # Go (golang.org/x/telemetry, added in Go 1.23)
 GOTELEMETRY=off
@@ -151,6 +184,16 @@ AZURE_CORE_COLLECT_TELEMETRY=0
 # AWS SAM CLI
 SAM_CLI_TELEMETRY=0
 
+# Azure Functions Core Tools (func CLI) — community reports this doesn't
+# always suppress telemetry reliably; see Azure/azure-functions-core-tools#1849
+FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT=1
+
+# Azure Static Web Apps CLI (swa)
+SWA_DISABLE_TELEMETRY=true
+
+# Microsoft Power Platform CLI (pac)
+PP_TOOLS_TELEMETRY_OPTOUT=1
+
 # Salesforce CLI (sf / sfdx)
 SF_DISABLE_TELEMETRY=true
 SFDX_DISABLE_TELEMETRY=true
@@ -192,11 +235,20 @@ MELTANO_DISABLE_TRACKING=true
 # Prisma (uses CHECKPOINT_DISABLE — already set above)
 
 # Quickwit
-DISABLE_QUICKWIT_TELEMETRY=1
+QW_DISABLE_TELEMETRY=1
+
+# Redgate Flyway (database migration CLI)
+REDGATE_DISABLE_TELEMETRY=true
 
 # ──────────────────────────────────────────────
 # API Clients & SDKs
 # ──────────────────────────────────────────────
+
+# Algolia CLI
+ALGOLIA_CLI_TELEMETRY=0
+
+# Argilla (ML data-annotation server) — inverted name, set to 0 to disable
+ARGILLA_ENABLE_TELEMETRY=0
 
 # Expo / React Native
 EXPO_NO_TELEMETRY=1
@@ -293,6 +345,12 @@ COCOAPODS_DISABLE_STATS=true
 # Dagster
 DAGSTER_DISABLE_TELEMETRY=1
 
+# Kedro (ML pipeline framework, kedro-telemetry plugin)
+KEDRO_DISABLE_TELEMETRY=1
+
+# n8n (workflow automation)
+N8N_DIAGNOSTICS_ENABLED=false
+
 # decK (Kong declarative config)
 DECK_ANALYTICS=off
 
@@ -302,7 +360,11 @@ ET_NO_TELEMETRY=1
 # F5 CLI
 F5_ALLOW_TELEMETRY=false
 
-# Gemini CLI
+# Gemini CLI — controls OpenTelemetry (OTLP) trace/metric export to a
+# user-configured backend, NOT Google's own usage-data collection, and
+# defaults to false already. The actual privacy opt-out is the interactive
+# `/privacy` command; there is no env var for it as of this writing.
+# Kept here for OTel-export clarity, not as a privacy opt-out.
 GEMINI_TELEMETRY_ENABLED=false
 
 # Hugging Face Hub (python transformers / diffusers / datasets)
@@ -403,3 +465,17 @@ AITOOLSVSCODE_DISABLETELEMETRY=1
 # TELEMETRY_ENABLED is a common pattern used by many tools. Setting this
 # globally may silently affect other tools in your environment.
 # TELEMETRY_ENABLED=0
+
+# Claude Code — disables usage metrics (DISABLE_TELEMETRY) and, as an
+# umbrella, all non-essential network traffic including error reporting,
+# the /feedback command, and session surveys (CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).
+# Community reports document that both variables also disable the client's
+# feature-flag evaluation (GrowthBook) as a side effect, which can gate off
+# unrelated product features rather than just telemetry:
+#   - anthropics/claude-code#34178, #58383, #73320, #47558, #53899
+# `DO_NOT_TRACK=1` at the top of this file triggers the same code path in
+# Claude Code, so this applies whether or not you uncomment the lines below.
+# Verify current behavior in your Claude Code version before relying on this.
+# Source: https://code.claude.com/docs/en/data-usage
+# DISABLE_TELEMETRY=1
+# CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1


### PR DESCRIPTION
## Summary

Works through the recurring findings from the weekly staleness-check issues (#14–#25), verifying each claim against primary sources (official docs, upstream GitHub issues/PRs) before acting rather than trusting the automated report at face value. A few things landed differently than proposed once checked:

- **Quickwit**: the file's existing `DISABLE_QUICKWIT_TELEMETRY=1` is a no-op upstream (confirmed against https://quickwit.io/docs/telemetry) — renamed to `QW_DISABLE_TELEMETRY=1`.
- **Angular CLI**: `NG_CLI_ANALYTICS_SHARE` removed — the `analyticsSharing` feature was dropped in Angular CLI v15 with no replacement (confirmed via the v15.0.0 release notes).
- **Webiny**: `REACT_APP_WEBINY_TELEMETRY` has no confirmed effect — it's a leftover Create React App convention from before Webiny dropped CRA, and current docs only mention a CLI-only opt-out. Replaced with an explanatory comment instead of a variable.
- **Gemini CLI**: kept `GEMINI_TELEMETRY_ENABLED=false` but added a comment — this variable actually controls OTel trace export, not Google's own usage-data collection, so it doesn't do what most readers would assume.

### New entries (15), verified against official docs/upstream PRs

.NET Upgrade Assistant, dotnet-scaffold, .NET HttpRepl, Microsoft.Testing.Platform, .NET Aspire CLI, Azure Functions Core Tools, Azure Static Web Apps CLI, Microsoft Power Platform CLI (pac), Kedro, n8n, Redgate Flyway, Storybook, MUI X, Algolia CLI, Argilla.

### Claude Code (#16, plus the proposal in #25/#15)

Added `DISABLE_TELEMETRY` / `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` to the **Aggressive/Opt-in** section (commented out) rather than the main list, since community reports (anthropics/claude-code#34178, #58383, #73320, #47558, #53899 — checked, all real) describe these also disabling client-side feature-flag evaluation as a side effect, gating off unrelated product features. Also added a note next to `DO_NOT_TRACK=1` at the top of the file, since that variable triggers the same code path and is already on by default in this project. Framed as a community-reported caveat, not an assertion about Anthropic's internal implementation.

## Not addressed here

- **Issue #2** (meta: "build a staleness-check process") — already implemented by the existing weekly workflow that files these issues; left open for you to close or scope further since it's not a content change.
- Flagsmith's `ENABLE_TELEMETRY` / `TELEMETRY_DISABLED` — left out per prior notes, name too generic (same rationale as the existing Aggressive section entries).

Local validation (duplicate-check, line-format check, count) from `.github/workflows/validate-env.yml` passes against the updated file (124 active variables, no dupes, no malformed lines).

Resolves #14, #15, #17, #18, #19, #20, #21, #22, #23, #24, #25, #16

## Test plan

- [x] Ran the three checks from `validate-env.yml` locally against the updated `do_not_track.env`
- [ ] CI (`validate-env.yml`) passes on this PR