### PR TITLE
chore: reorganize do_not_track.env into alphabetized categories

### DIFF
--- a/do_not_track.env
+++ b/do_not_track.env
@@ -8,6 +8,10 @@
 #   Docker Compose:     env_file: do_not_track.env
 #   CI/CD:              export vars in your pipeline environment
 #
+# Structure: sections are grouped by category; entries within each section
+# are alphabetical by tool name (closely related tools/providers are kept
+# adjacent even where that bends strict alphabetical order).
+#
 # Source: https://github.com/alloydwhitlock/do-not-track-cli
 # Contributing: see README.md
 
@@ -19,10 +23,50 @@
 # See: https://donottrack.sh
 #
 # Known interaction: in Claude Code, DO_NOT_TRACK=1 triggers the same
-# non-default privacy code path as DISABLE_TELEMETRY, which community
-# reports say also disables client-side feature-flag evaluation (GrowthBook)
-# — see the Claude Code entry in the "Aggressive / Opt-in" section below.
+# privacy code path as DISABLE_TELEMETRY — see the Claude Code entry in
+# "AI Coding Assistants & IDE Tools" below for current status.
 DO_NOT_TRACK=1
+
+# ──────────────────────────────────────────────
+# AI Coding Assistants & IDE Tools
+# ──────────────────────────────────────────────
+
+# Azure Application Insights VSCode extension
+AITOOLSVSCODE_DISABLETELEMETRY=1
+
+# Claude Code — DISABLE_TELEMETRY and, as an umbrella, all non-essential
+# network traffic including error reporting, the /feedback command, and
+# session surveys (CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC). Anthropic's
+# docs now confirm both also disable the feature-flag evaluation that
+# Remote Control depends on:
+#   https://code.claude.com/docs/en/data-usage (see "Telemetry services")
+# `DO_NOT_TRACK=1` at the top of this file triggers the same code path in
+# Claude Code, so this applies whether or not you uncomment the lines below.
+# Status as verified against anthropics/claude-code:
+#   - One specific gate (Agent View / `claude agents` / `--bg`) was
+#     decoupled from this and fixed in v2.1.140 (issue #58383).
+#   - Remote Control itself is still coupled to this as of v2.1.199, with
+#     no fix in the changelog through the current v2.1.226 — and DO_NOT_TRACK
+#     specifically (not just DISABLE_TELEMETRY) is confirmed part of the same
+#     gate check (issue #76748, open).
+# Verify current behavior in your Claude Code version before relying on this.
+# DISABLE_TELEMETRY=1
+# CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+
+# Gemini CLI — controls OpenTelemetry (OTLP) trace/metric export to a
+# user-configured backend, NOT Google's own usage-data collection, and
+# defaults to false already. The actual privacy opt-out is the interactive
+# `/privacy` command; there is no env var for it as of this writing.
+# Kept here for OTel-export clarity, not as a privacy opt-out.
+GEMINI_TELEMETRY_ENABLED=false
+
+# JavaScript debugger (VSCode)
+DA_TEST_DISABLE_TELEMETRY=1
+
+# projector-cli — disables telemetry for JetBrains projector-cli, but
+# TELEMETRY_ENABLED is a common pattern used by many tools. Setting this
+# globally may silently affect other tools in your environment.
+# TELEMETRY_ENABLED=0
 
 # ──────────────────────────────────────────────
 # JavaScript / TypeScript Frameworks
@@ -36,8 +80,15 @@ NG_CLI_ANALYTICS=false
 # Astro
 ASTRO_TELEMETRY_DISABLED=1
 
+# Cube.js
+CUBEJS_TELEMETRY=false
+
 # Gatsby
 GATSBY_TELEMETRY_DISABLED=1
+
+# MUI X (@mui/x-* packages: Data Grid, Date Pickers, Charts)
+# Must be set in the Node.js process environment (not NEXT_PUBLIC_/REACT_APP_-prefixed).
+MUI_X_TELEMETRY_DISABLED=true
 
 # Next.js
 NEXT_TELEMETRY_DISABLED=1
@@ -45,13 +96,16 @@ NEXT_TELEMETRY_DISABLED=1
 # Nuxt.js
 NUXT_TELEMETRY_DISABLED=1
 
-# Strapi
-STRAPI_TELEMETRY_DISABLED=true
-STRAPI_DISABLE_UPDATE_NOTIFICATION=true
+# SKU (Seek's build toolchain)
+SKU_TELEMETRY=false
 
 # Storybook (env var is required; the main.js config option alone doesn't
 # suppress the boot-time telemetry event)
 STORYBOOK_DISABLE_TELEMETRY=1
+
+# Strapi
+STRAPI_TELEMETRY_DISABLED=true
+STRAPI_DISABLE_UPDATE_NOTIFICATION=true
 
 # Turborepo
 TURBO_TELEMETRY_DISABLED=1
@@ -66,16 +120,6 @@ HINT_TELEMETRY=off
 # Create React App convention from before Webiny dropped CRA; current docs
 # only document `yarn webiny disable-telemetry` (CLI-only opt-out).
 # See: https://www.webiny.com/docs/webiny-telemetry/webiny-telemetry
-
-# MUI X (@mui/x-* packages: Data Grid, Date Pickers, Charts)
-# Must be set in the Node.js process environment (not NEXT_PUBLIC_/REACT_APP_-prefixed).
-MUI_X_TELEMETRY_DISABLED=true
-
-# SKU (Seek's build toolchain)
-SKU_TELEMETRY=false
-
-# Cube.js
-CUBEJS_TELEMETRY=false
 
 # ──────────────────────────────────────────────
 # Package Managers & Dependency Tools
@@ -92,31 +136,11 @@ YARN_ENABLE_TELEMETRY=0
 # Language Runtimes & Build Tools
 # ──────────────────────────────────────────────
 
-# .NET Core SDK
-DOTNET_CLI_TELEMETRY_OPTOUT=1
+# Bun (also respects DO_NOT_TRACK=1 above)
+# BUN_DISABLE_TELEMETRY=1  # future; currently DO_NOT_TRACK=1 is sufficient
 
-# .NET Interactive
-DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=1
-
-# dotnet-svcutil
-DOTNET_SVCUTIL_TELEMETRY_OPTOUT=1
-
-# .NET Upgrade Assistant (tool is officially deprecated in favor of the
-# GitHub Copilot modernization agent, but still ships this opt-out)
-DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT=1
-
-# dotnet-scaffold (ASP.NET Core scaffolding CLI, .NET 9+)
-DOTNET_SCAFFOLD_TELEMETRY_OPTOUT=1
-
-# .NET HttpRepl
-DOTNET_HTTPREPL_TELEMETRY_OPTOUT=1
-
-# Microsoft.Testing.Platform (xUnit v3, NUnit, MSTest on the new test runner;
-# DOTNET_CLI_TELEMETRY_OPTOUT above also satisfies this)
-TESTINGPLATFORM_TELEMETRY_OPTOUT=1
-
-# .NET Aspire CLI
-ASPIRE_CLI_TELEMETRY_OPTOUT=true
+# choosenim (Nim version manager)
+CHOOSENIM_NO_ANALYTICS=1
 
 # Go (golang.org/x/telemetry, added in Go 1.23)
 GOTELEMETRY=off
@@ -127,21 +151,56 @@ MLDOTNET_CLI_TELEMETRY_OPTOUT=1
 # mssql-cli
 MSSQL_CLI_TELEMETRY_OPTOUT=1
 
-# PowerShell Core
-POWERSHELL_TELEMETRY_OPTOUT=1
+# .NET Aspire CLI
+ASPIRE_CLI_TELEMETRY_OPTOUT=true
 
-# Bun (also respects DO_NOT_TRACK=1 above)
-# BUN_DISABLE_TELEMETRY=1  # future; currently DO_NOT_TRACK=1 is sufficient
+# .NET Core SDK
+DOTNET_CLI_TELEMETRY_OPTOUT=1
 
-# choosenim (Nim version manager)
-CHOOSENIM_NO_ANALYTICS=1
+# .NET HttpRepl
+DOTNET_HTTPREPL_TELEMETRY_OPTOUT=1
+
+# .NET Interactive
+DOTNET_INTERACTIVE_CLI_TELEMETRY_OPTOUT=1
+
+# dotnet-scaffold (ASP.NET Core scaffolding CLI, .NET 9+)
+DOTNET_SCAFFOLD_TELEMETRY_OPTOUT=1
+
+# dotnet-svcutil
+DOTNET_SVCUTIL_TELEMETRY_OPTOUT=1
+
+# Microsoft.Testing.Platform (xUnit v3, NUnit, MSTest on the new test runner;
+# DOTNET_CLI_TELEMETRY_OPTOUT above also satisfies this)
+TESTINGPLATFORM_TELEMETRY_OPTOUT=1
+
+# .NET Upgrade Assistant (tool is officially deprecated in favor of the
+# GitHub Copilot modernization agent, but still ships this opt-out)
+DOTNET_UPGRADEASSISTANT_TELEMETRY_OPTOUT=1
 
 # Nuke (build system for .NET)
 NUKE_TELEMETRY_OPTOUT=1
 
+# PowerShell Core
+POWERSHELL_TELEMETRY_OPTOUT=1
+
 # ──────────────────────────────────────────────
 # Infrastructure as Code
 # ──────────────────────────────────────────────
+
+# AWS CDK
+CDK_DISABLE_CLI_TELEMETRY=true
+
+# Batect
+BATECT_ENABLE_TELEMETRY=false
+
+# Earthly
+EARTHLY_DISABLE_ANALYTICS=1
+
+# Pants (Python build system)
+PANTS_ANONYMOUS_TELEMETRY_ENABLED=false
+
+# Pulumi
+PULUMI_SKIP_UPDATE_CHECK=true
 
 # Terraform / OpenTofu / Packer / Vault / Consul / Weave Net / WKSctl / CDK for Terraform
 # CHECKPOINT_DISABLE is a HashiCorp-wide convention used by multiple tools.
@@ -153,39 +212,21 @@ ARM_DISABLE_TERRAFORM_PARTNER_ID=true
 # F5 BIG-IP Terraform provider
 TEEM_DISABLE=true
 
-# Pulumi
-PULUMI_SKIP_UPDATE_CHECK=true
-
-# Earthly
-EARTHLY_DISABLE_ANALYTICS=1
-
-# Batect
-BATECT_ENABLE_TELEMETRY=false
-
-# Pants (Python build system)
-PANTS_ANONYMOUS_TELEMETRY_ENABLED=false
-
 # werf
 WERF_TELEMETRY=0
-
-# AWS CDK
-CDK_DISABLE_CLI_TELEMETRY=true
 
 # ──────────────────────────────────────────────
 # Cloud Provider CLIs
 # ──────────────────────────────────────────────
 
-# Google Cloud SDK (gcloud)
-CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
+# AWS SAM CLI
+SAM_CLI_TELEMETRY=0
 
 # Azure CLI
 AZURE_CORE_COLLECT_TELEMETRY=0
 
 # Azure Developer CLI (azd) — separate tool from Azure CLI (az) above
 AZURE_DEV_COLLECT_TELEMETRY=false
-
-# AWS SAM CLI
-SAM_CLI_TELEMETRY=0
 
 # Azure Functions Core Tools (func CLI) — community reports this doesn't
 # always suppress telemetry reliably; see Azure/azure-functions-core-tools#1849
@@ -194,15 +235,24 @@ FUNCTIONS_CORE_TOOLS_TELEMETRY_OPTOUT=1
 # Azure Static Web Apps CLI (swa)
 SWA_DISABLE_TELEMETRY=true
 
+# Cloudflare Wrangler
+WRANGLER_SEND_METRICS=false
+
+# GitHub CLI (gh) — added in v2.91.0, April 2026
+GH_TELEMETRY=false
+
+# Google Cloud SDK (gcloud)
+CLOUDSDK_CORE_DISABLE_USAGE_REPORTING=true
+
 # Microsoft Power Platform CLI (pac)
 PP_TOOLS_TELEMETRY_OPTOUT=1
+
+# Railway (also respects DO_NOT_TRACK=1 above)
+RAILWAY_NO_TELEMETRY=1
 
 # Salesforce CLI (sf / sfdx)
 SF_DISABLE_TELEMETRY=true
 SFDX_DISABLE_TELEMETRY=true
-
-# GitHub CLI (gh) — added in v2.91.0, April 2026
-GH_TELEMETRY=false
 
 # Supabase CLI (also respects DO_NOT_TRACK=1 above)
 SUPABASE_TELEMETRY_DISABLED=1
@@ -210,15 +260,12 @@ SUPABASE_TELEMETRY_DISABLED=1
 # Vercel CLI
 VERCEL_TELEMETRY_DISABLED=1
 
-# Railway (also respects DO_NOT_TRACK=1 above)
-RAILWAY_NO_TELEMETRY=1
-
-# Cloudflare Wrangler
-WRANGLER_SEND_METRICS=false
-
 # ──────────────────────────────────────────────
 # Databases & Data Platforms
 # ──────────────────────────────────────────────
+
+# Hasura GraphQL Engine
+HASURA_GRAPHQL_ENABLE_TELEMETRY=false
 
 # InfluxDB
 INFLUXD_REPORTING_DISABLED=true
@@ -226,14 +273,11 @@ INFLUXD_REPORTING_DISABLED=true
 # MeiliSearch
 MEILI_NO_ANALYTICS=true
 
-# NocoDB
-NC_DISABLE_TELE=1
-
-# Hasura GraphQL Engine
-HASURA_GRAPHQL_ENABLE_TELEMETRY=false
-
 # Meltano
 MELTANO_DISABLE_TRACKING=true
+
+# NocoDB
+NC_DISABLE_TELE=1
 
 # Prisma (uses CHECKPOINT_DISABLE — already set above)
 
@@ -253,6 +297,12 @@ ALGOLIA_CLI_TELEMETRY=0
 # Argilla (ML data-annotation server) — inverted name, set to 0 to disable
 ARGILLA_ENABLE_TELEMETRY=0
 
+# Canvas LMS
+CANVAS_LMS_STATS_COLLECTION=opt_out
+
+# Encore
+DISABLE_ENCORE_TELEMETRY=1
+
 # Expo / React Native
 EXPO_NO_TELEMETRY=1
 
@@ -266,12 +316,6 @@ FEAST_TELEMETRY=false
 MM_LOGSETTINGS_ENABLEDIAGNOSTICS=false
 MM_SERVICESETTINGS_ENABLESECURITYFIXALERT=false
 
-# Canvas LMS
-CANVAS_LMS_STATS_COLLECTION=opt_out
-
-# otel-launcher-node (Lightstep host metrics)
-LS_METRICS_HOST_ENABLED=0
-
 # One Codex
 ONE_CODEX_NO_TELEMETRY=true
 
@@ -281,14 +325,20 @@ SQA_OPT_OUT=true
 # Oryx (Microsoft build tool)
 ORYX_DISABLE_TELEMETRY=true
 
+# otel-launcher-node (Lightstep host metrics)
+LS_METRICS_HOST_ENABLED=0
+
 # PROSE Code Accelerator SDK (Microsoft Research)
 PROSE_TELEMETRY_OPTOUT=1
+
+# Quilt (data versioning)
+QUILT_DISABLE_USAGE_METRICS=true
 
 # RASA (conversational AI)
 RASA_TELEMETRY_ENABLED=false
 
-# Quilt (data versioning)
-QUILT_DISABLE_USAGE_METRICS=true
+# Redocly CLI
+REDOCLY_TELEMETRY=off
 
 # ReportPortal
 REPORTPORTAL_CLIENT_JS_NO_ANALYTICS=true
@@ -306,12 +356,6 @@ APOLLO_TELEMETRY_DISABLED=1
 # Salto CLI
 SALTO_TELEMETRY_DISABLE=1
 
-# Redocly CLI
-REDOCLY_TELEMETRY=off
-
-# Encore
-DISABLE_ENCORE_TELEMETRY=1
-
 # Stripe CLI
 STRIPE_CLI_TELEMETRY_OPTOUT=1
 
@@ -327,17 +371,30 @@ SLS_TRACKING_DISABLED=1
 # DevOps & Platform Tools
 # ──────────────────────────────────────────────
 
+# aliBuild (ALICE/CERN)
+ALIBUILD_NO_ANALYTICS=1
+
 # App Center CLI
 MOBILE_CENTER_TELEMETRY=off
-
-# Arduino CLI
-ARDUINO_METRICS_ENABLED=false
 
 # Appc Daemon (Titanium)
 APPCD_TELEMETRY=0
 
+# Arduino CLI
+ARDUINO_METRICS_ENABLED=false
+
+# Automagica
+AUTOMAGICA_NO_TELEMETRY=1
+
+# AutomatedLab
+AUTOMATEDLAB_TELEMETRY_OPTIN=0
+AUTOMATEDLAB_TELEMETRY_OPTOUT=1
+
 # Bot Framework CLI
 BF_CLI_TELEMETRY=false
+
+# Carbon Design System
+CARBON_TELEMETRY_DISABLED=1
 
 # Chef Workstation
 CHEF_TELEMETRY_OPT_OUT=1
@@ -345,14 +402,11 @@ CHEF_TELEMETRY_OPT_OUT=1
 # CocoaPods
 COCOAPODS_DISABLE_STATS=true
 
+# Dagger (also respects DO_NOT_TRACK=1)
+# DO_NOT_TRACK is already set above
+
 # Dagster
 DAGSTER_DISABLE_TELEMETRY=1
-
-# Kedro (ML pipeline framework, kedro-telemetry plugin)
-KEDRO_DISABLE_TELEMETRY=1
-
-# n8n (workflow automation)
-N8N_DIAGNOSTICS_ENABLED=false
 
 # decK (Kong declarative config)
 DECK_ANALYTICS=off
@@ -363,24 +417,20 @@ ET_NO_TELEMETRY=1
 # F5 CLI
 F5_ALLOW_TELEMETRY=false
 
-# Gemini CLI — controls OpenTelemetry (OTLP) trace/metric export to a
-# user-configured backend, NOT Google's own usage-data collection, and
-# defaults to false already. The actual privacy opt-out is the interactive
-# `/privacy` command; there is no env var for it as of this writing.
-# Kept here for OTel-export clarity, not as a privacy opt-out.
-GEMINI_TELEMETRY_ENABLED=false
+# Hookdeck CLI
+HOOKDECK_CLI_TELEMETRY_OPTOUT=1
 
 # Hugging Face Hub (python transformers / diffusers / datasets)
 HF_HUB_DISABLE_TELEMETRY=1
-
-# Hookdeck CLI
-HOOKDECK_CLI_TELEMETRY_OPTOUT=1
 
 # Humbug (Python library used by several tools)
 BUGGER_OFF=1
 
 # Infracost
 INFRACOST_SELF_HOSTED_TELEMETRY=false
+
+# Kedro (ML pipeline framework, kedro-telemetry plugin)
+KEDRO_DISABLE_TELEMETRY=1
 
 # KICS (security scanner)
 KICS_COLLECT_TELEMETRY=0
@@ -389,11 +439,17 @@ DISABLE_CRASH_REPORT=1
 # kPow (Kafka UI)
 ALLOW_UI_ANALYTICS=false
 
+# kubeapt (Kubernetes dashboard)
+DASH_DISABLE_TELEMETRY=1
+
 # LYNX VFX
 LYNX_ANALYTICS=0
 
 # MSLab
 MSLAB_TELEMETRY_LEVEL=None
+
+# n8n (workflow automation)
+N8N_DIAGNOSTICS_ENABLED=false
 
 # Netdata (also respects DO_NOT_TRACK=1 above)
 # DO_NOT_TRACK is already set above
@@ -403,6 +459,9 @@ PNPPOWERSHELL_DISABLETELEMETRY=true
 
 # Telepresence (CNCF)
 SCOUT_DISABLE=1
+
+# Testim Root Cause (failure analysis)
+SUGGESTIONS_OPT_OUT=1
 
 # Tilt (k8s dev tool; also respects DO_NOT_TRACK=1)
 # DO_NOT_TRACK is already set above
@@ -417,34 +476,6 @@ VAGRANT_BOX_UPDATE_CHECK_DISABLE=1
 # vstest
 VSTEST_TELEMETRY_OPTEDIN=0
 
-# AutomatedLab
-AUTOMATEDLAB_TELEMETRY_OPTIN=0
-AUTOMATEDLAB_TELEMETRY_OPTOUT=1
-
-# Dagger (also respects DO_NOT_TRACK=1)
-# DO_NOT_TRACK is already set above
-
-# aliBuild (ALICE/CERN)
-ALIBUILD_NO_ANALYTICS=1
-
-# kubeapt (Kubernetes dashboard)
-DASH_DISABLE_TELEMETRY=1
-
-# Testim Root Cause (failure analysis)
-SUGGESTIONS_OPT_OUT=1
-
-# Carbon Design System
-CARBON_TELEMETRY_DISABLED=1
-
-# Automagica
-AUTOMAGICA_NO_TELEMETRY=1
-
-# JavaScript debugger (VSCode)
-DA_TEST_DISABLE_TELEMETRY=1
-
-# Azure Application Insights VSCode extension
-AITOOLSVSCODE_DISABLETELEMETRY=1
-
 # ──────────────────────────────────────────────
 # Aggressive / Opt-in
 # ──────────────────────────────────────────────
@@ -454,31 +485,12 @@ AITOOLSVSCODE_DISABLETELEMETRY=1
 #
 # Uncomment only the ones you want, and verify they don't break other tools.
 
-# Hugging Face Hub — blocks ALL outbound connections to hf.co.
-# This prevents model and dataset downloads, not just usage reporting.
-# Only set this in fully offline or air-gapped environments.
-# HF_HUB_OFFLINE=1
-
 # AccessMap — disables analytics for the AccessMap routing tool, but the
 # variable name ANALYTICS is generic enough to interfere with other tools
 # that check $ANALYTICS in their own startup logic.
 # ANALYTICS=no
 
-# projector-cli — disables telemetry for JetBrains projector-cli, but
-# TELEMETRY_ENABLED is a common pattern used by many tools. Setting this
-# globally may silently affect other tools in your environment.
-# TELEMETRY_ENABLED=0
-
-# Claude Code — disables usage metrics (DISABLE_TELEMETRY) and, as an
-# umbrella, all non-essential network traffic including error reporting,
-# the /feedback command, and session surveys (CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC).
-# Community reports document that both variables also disable the client's
-# feature-flag evaluation (GrowthBook) as a side effect, which can gate off
-# unrelated product features rather than just telemetry:
-#   - anthropics/claude-code#34178, #58383, #73320, #47558, #53899
-# `DO_NOT_TRACK=1` at the top of this file triggers the same code path in
-# Claude Code, so this applies whether or not you uncomment the lines below.
-# Verify current behavior in your Claude Code version before relying on this.
-# Source: https://code.claude.com/docs/en/data-usage
-# DISABLE_TELEMETRY=1
-# CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1
+# Hugging Face Hub — blocks ALL outbound connections to hf.co.
+# This prevents model and dataset downloads, not just usage reporting.
+# Only set this in fully offline or air-gapped environments.
+# HF_HUB_OFFLINE=1


### PR DESCRIPTION
## Summary

- Groups entries by category with alphabetical ordering within each section. Closely related tool families (.NET/dotnet, Azure, Terraform) are kept adjacent even where that bends strict letter order, since grouping the same ecosystem together reads better than splitting it across the alphabet.
- Adds a new **AI Coding Assistants & IDE Tools** section positioned right after Universal (2nd section overall) so Claude Code, Gemini CLI, and editor/IDE-related telemetry entries (VSCode extensions, JetBrains projector-cli) are near the top for developers, rather than scattered across DevOps/Aggressive sections.
- Pure reorganization — verified via diff that the set of active (`VAR=value`) and commented-out variable lines is byte-identical to `origin/main`. No values changed, nothing added or dropped.

## Issue #16 re-verified

Checked current status against `anthropics/claude-code` rather than trusting the old citations as-is:

- Anthropic's docs now **officially** state (`data-usage.md`, "Telemetry services"): *"Setting `DISABLE_TELEMETRY` or `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC` also disables the feature-flag evaluation that Remote Control depends on."* This was previously only described in the file as "community reports."
- One narrower case — the Agent View gate (`claude agents` / `--bg`) — was decoupled and fixed in **v2.1.140** (anthropics/claude-code#58383).
- Remote Control itself is **still broken** as of v2.1.199 (anthropics/claude-code#76748, open, no comments/fix), with no relevant changelog entry through the current v2.1.226. That report also confirms `DO_NOT_TRACK` specifically (not just `DISABLE_TELEMETRY`) is part of the same gate check.

Updated the Claude Code comment block to reflect this precise, current picture instead of the old general "community reports" framing.

## Test plan

- [x] `diff` of active var lines (new vs. `origin/main`) — empty
- [x] `diff` of commented-out var lines (new vs. `origin/main`) — empty
- [x] Ran the three `validate-env.yml` checks locally: no duplicates, valid line format, 125 active variables (unchanged count)
- [ ] CI (`validate-env.yml`) passes on this PR